### PR TITLE
feat: add telescope.nvim

### DIFF
--- a/.necromancer.json
+++ b/.necromancer.json
@@ -29,6 +29,17 @@
       "name": "seeker.nvim",
       "repo": "https://github.com/sontixyou/seeker.nvim",
       "commit": "d0a855496920b5bf22136af56cc96105b3210193"
+    },
+    {
+      "name": "plenary.nvim",
+      "repo": "https://github.com/nvim-lua/plenary.nvim",
+      "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509"
+    },
+    {
+      "name": "telescope.nvim",
+      "repo": "https://github.com/nvim-telescope/telescope.nvim",
+      "commit": "b4da76be54691e854d3e0e02c36b0245f945c2c7",
+      "dependencies": ["plenary.nvim"]
     }
   ]
 }

--- a/.necromancer.lock
+++ b/.necromancer.lock
@@ -1,48 +1,62 @@
 {
   "version": "1",
-  "generated": "2025-10-14T00:47:41.989Z",
+  "generated": "2025-10-15T15:02:43.614Z",
   "plugins": [
     {
       "name": "denops-helloworld",
       "repo": "https://github.com/vim-denops/denops-helloworld.vim",
       "commit": "f975281571191cfd4e3f9e5ba77103932f7dd6e5",
-      "installedAt": "2025-10-14T00:47:41.171Z",
+      "installedAt": "2025-10-15T15:02:43.472Z",
       "path": "~/.local/share/nvim/necromancer/plugins/denops-helloworld"
     },
     {
       "name": "denops.vim",
       "repo": "https://github.com/vim-denops/denops.vim",
       "commit": "a278b8342459e4687f24d4d575d72ff593326cee",
-      "installedAt": "2025-10-14T00:47:41.148Z",
+      "installedAt": "2025-10-15T15:02:43.450Z",
       "path": "~/.local/share/nvim/necromancer/plugins/denops.vim"
     },
     {
       "name": "nvim-treesitter",
       "repo": "https://github.com/nvim-treesitter/nvim-treesitter",
       "commit": "3ab4f2d2d20be55874e2eb575145c6928d7d7d0e",
-      "installedAt": "2025-10-14T00:47:41.191Z",
+      "installedAt": "2025-10-15T15:02:43.518Z",
       "path": "~/.local/share/nvim/necromancer/plugins/nvim-treesitter"
     },
     {
       "name": "vim-test",
       "repo": "https://github.com/vim-test/vim-test",
       "commit": "ad4b7213568d59a5e37606ad65859e3a8e45dbd2",
-      "installedAt": "2025-10-14T00:47:41.212Z",
+      "installedAt": "2025-10-15T15:02:43.539Z",
       "path": "~/.local/share/nvim/necromancer/plugins/vim-test"
     },
     {
       "name": "treesj",
       "repo": "https://github.com/Wansmer/treesj",
       "commit": "4770492244ccecdc9b01e0e81fa8f2f6b4a23841",
-      "installedAt": "2025-10-14T00:47:41.232Z",
+      "installedAt": "2025-10-15T15:02:43.558Z",
       "path": "~/.local/share/nvim/necromancer/plugins/treesj"
     },
     {
       "name": "seeker.nvim",
       "repo": "https://github.com/sontixyou/seeker.nvim",
       "commit": "d0a855496920b5bf22136af56cc96105b3210193",
-      "installedAt": "2025-10-14T00:47:41.989Z",
+      "installedAt": "2025-10-15T15:02:43.577Z",
       "path": "~/.local/share/nvim/necromancer/plugins/seeker.nvim"
+    },
+    {
+      "name": "telescope.nvim",
+      "repo": "https://github.com/nvim-telescope/telescope.nvim",
+      "commit": "b4da76be54691e854d3e0e02c36b0245f945c2c7",
+      "installedAt": "2025-10-15T15:02:43.614Z",
+      "path": "~/.local/share/nvim/necromancer/plugins/telescope.nvim"
+    },
+    {
+      "name": "plenary.nvim",
+      "repo": "https://github.com/nvim-lua/plenary.nvim",
+      "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509",
+      "installedAt": "2025-10-15T15:02:43.596Z",
+      "path": "~/.local/share/nvim/necromancer/plugins/plenary.nvim"
     }
   ]
 }

--- a/init.lua
+++ b/init.lua
@@ -109,12 +109,19 @@ require'nvim-treesitter'.setup {
   },
 }
 
+local builtin = require('telescope.builtin')
+vim.keymap.set('n', '<leader><leader>', builtin.find_files, { desc = 'Telescope find files' })
+vim.keymap.set('n', '<leader>fg', builtin.live_grep, { desc = 'Telescope live grep' })
+vim.keymap.set('n', '<leader>fb', builtin.buffers, { desc = 'Telescope buffers' })
+vim.keymap.set('n', '<leader>fh', builtin.help_tags, { desc = 'Telescope help tags' })
+
+
 -- Configure seeker.nvim keybinding
-vim.api.nvim_create_autocmd('User', {
-  pattern = 'DenopsReady',
-  callback = function()
-    vim.keymap.set('n', '<leader><leader>', function()
-      vim.fn['denops#notify']('seeker', 'findFiles', {})
-    end, { desc = 'Find Files', noremap = true, silent = true })
-  end,
-})
+-- vim.api.nvim_create_autocmd('User', {
+--   pattern = 'DenopsReady',
+--   callback = function()
+--     vim.keymap.set('n', '<leader><leader>', function()
+--       vim.fn['denops#notify']('seeker', 'findFiles', {})
+--     end, { desc = 'Find Files', noremap = true, silent = true })
+--   end,
+-- })


### PR DESCRIPTION
## Summary

- Add telescope.nvim plugin with plenary.nvim dependency for enhanced file finding and fuzzy searching
- Configure telescope keybindings for common operations
- Update seeker.nvim configuration (commented out overlapping keybinding)

## Changes

- `.necromancer.json`: Added plenary.nvim and telescope.nvim with dependency declaration
- `.necromancer.lock`: Updated with new plugin installation records
- `init.lua`: Added telescope keybindings and commented out conflicting seeker.nvim keybinding

## Keybindings

- `<leader><leader>`: Find files (replaces seeker.nvim)
- `<leader>fg`: Live grep
- `<leader>fb`: Buffers
- `<leader>fh`: Help tags

## Test plan

- [ ] Verify telescope.nvim loads correctly
- [ ] Test `<leader><leader>` for file finding
- [ ] Test `<leader>fg` for live grep functionality
- [ ] Test `<leader>fb` for buffer navigation
- [ ] Test `<leader>fh` for help tags search
- [ ] Confirm plenary.nvim dependency is properly resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)