### PR TITLE
feat: add yank highlight with orange color

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -35,6 +35,17 @@ vim.api.nvim_create_autocmd({ "FocusGained", "BufEnter", "CursorHold", "CursorHo
   end,
 })
 
+-- Highlight yanked text with orange color
+vim.api.nvim_set_hl(0, 'YankHighlight', { bg = '#ff9e64', fg = '#000000' })
+vim.api.nvim_create_autocmd('TextYankPost', {
+  callback = function()
+    vim.highlight.on_yank({
+      higroup = 'YankHighlight',
+      timeout = 300,
+    })
+  end,
+})
+
 
 -- keymap
 keymap.set("i", "jj", "<ESC>", opts)


### PR DESCRIPTION
## Summary

- Adds visual feedback when text is yanked in Neovim
- Highlights yanked text with orange background (#ff9e64) for 300ms
- Uses `TextYankPost` autocmd with `vim.highlight.on_yank()` for implementation
- Improves user experience by making yank operations more visible

## Implementation Details

**Configuration Added:**
- Custom highlight group `YankHighlight` with orange background (`#ff9e64`) and black foreground
- `TextYankPost` autocmd that triggers `vim.highlight.on_yank()` after every yank operation
- 300ms timeout for the highlight effect

**User Experience:**
- When using `yy`, `y`+motion, or any yank command, the yanked text will briefly flash orange
- Makes it easy to see exactly what was yanked, preventing confusion
- Non-intrusive with a short 300ms display time

## Test plan

- [x] Open a file in Neovim
- [x] Test `yy` to yank a line - verify orange highlight appears
- [x] Test `yiw` to yank a word - verify orange highlight appears
- [x] Test visual mode `v` + selection + `y` - verify orange highlight appears
- [x] Verify the highlight disappears after 300ms
- [x] Verify normal yank functionality still works (paste with `p`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)